### PR TITLE
(#4203) zvol logical block size should be the same as physical block

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1412,6 +1412,7 @@ zvol_create_minor_impl(const char *name)
 	blk_queue_max_segments(zv->zv_queue, UINT16_MAX);
 	blk_queue_max_segment_size(zv->zv_queue, UINT_MAX);
 	blk_queue_physical_block_size(zv->zv_queue, zv->zv_volblocksize);
+	blk_queue_logical_block_size(zv->zv_queue, zv->zv_volblocksize);
 	blk_queue_io_opt(zv->zv_queue, zv->zv_volblocksize);
 	blk_queue_max_discard_sectors(zv->zv_queue,
 	    (zvol_max_discard_blocks * zv->zv_volblocksize) >> 9);


### PR DESCRIPTION
This is just a quick implementation of #4203

Signed-off-by: Kash Pande <kash@tripleback.net>